### PR TITLE
feat!: migrate to Java 17 and from compatibility with older Java versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,13 +23,19 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+    - name: Setup Java
+      uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
+      with:
+        java-version: 17
+        distribution: temurin
+        cache: maven
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
       with:
-        languages: ${{ matrix.language }}
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+        languages: java
+    - name: Build
+      run: mvn package
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
       with:
-        category: "/language:${{matrix.language}}"
+        category: /language:java

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           # Useful for SonarCloud Scans
           fetch-depth: 0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Setup Java
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: 17
+          distribution: temurin
           cache: maven
       - name: Build & Test
         run: mvn ${{ env.MAVEN_CLI_OPTS }} install

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk11
+  - openjdk17

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <project.encoding>UTF-8</project.encoding>
     <project.build.sourceEncoding>${project.encoding}</project.build.sourceEncoding>
     <project.reporting.outputEncoding>${project.encoding}</project.reporting.outputEncoding>
-    <java.version>8</java.version>
+    <java.version>17</java.version>
 
     <!-- ==================== Sonar ==================== -->
     <!-- sonar.projectKey must be defined through CLI only -->
@@ -266,7 +266,7 @@
             <dependencyConvergence />
             <reactorModuleConvergence />
             <requireJavaVersion>
-              <version>[11,12)</version>
+              <version>[17,18)</version>
             </requireJavaVersion>
             <requireMavenVersion>
               <version>[3.8,)</version>


### PR DESCRIPTION
We can migrate to Java 17 without fear since the project relying on this library has already migrated to this version.

BREAKING-CHANGE: minimal Java version is now set to v17