### PR TITLE
ci(release): deactivate the CD pipeline

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,26 +31,3 @@ jobs:
         run: mvn sonar:sonar -Dsonar.projectKey=Djaytan_bukkit-slf4j
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-  # Note: Artifacts can be retrieved with Jitpack based on tags -> No need to deploy
-  cd:
-    name: CD
-    needs: ci
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Prepare
-        uses: qcastel/github-actions-maven-release@v1.12.41
-        env:
-          JAVA_HOME: /usr/lib/jvm/java-11-openjdk/
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          maven-args: ${{ env.MAVEN_CLI_OPTS }} -DskipTests=true -DskipITs=true -Dfmt.skip=true -Dsort.skip=true -Denforcer.skip=true -Dmaven.javadoc.skip=true
-          release-branch-name: 'main'
-          skip-perform: true
-          git-release-bot-email: '41898282+github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
Will be replaced by a new solution based on `semantic-release`.
