### PR TITLE
ci(release): auto-release artifacts through the Nexus Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,11 +97,6 @@
                     <artifactId>maven-install-plugin</artifactId>
                     <version>3.1.1</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.1</version>
-                </plugin>
 
                 <!-- Formatting-related plugins -->
                 <plugin>
@@ -183,8 +178,10 @@
                             </requireMavenVersion>
                             <requirePluginVersions>
                                 <message>Best Practice is to always define plugin versions!</message>
+                                <!-- The Nexus one replaces the Maven deploy plugin -->
                                 <!-- "site" phase is not applicable for this project -->
-                                <unCheckedPluginList>org.apache.maven.plugins:maven-site-plugin</unCheckedPluginList>
+                                <unCheckedPluginList>org.apache.maven.plugins:maven-deploy-plugin,
+                                    org.apache.maven.plugins:maven-site-plugin</unCheckedPluginList>
                             </requirePluginVersions>
                             <requireUpperBoundDeps />
                         </rules>
@@ -237,6 +234,17 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.13</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <serverId>ossrh</serverId>
+                        <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    </configuration>
                 </plugin>
 
                 <!-- SonarCloud code quality scans -->


### PR DESCRIPTION
#### Introduction

Initially, only the `maven-deploy-plugin` was used for publishing artifacts to the Sonatype repository (https://s01.oss.sonatype.org). However, publishing the artifacts are not enough since they fall into a "Staging" repository, meaning that some additional actions are required to promote to the "Release" one. That's not something the Maven deploy plugin handle.

---

#### How things work with a Nexus repository

For giving more details about the specific actions required to be done (manually for now, hence this change for having full automation):
1. Once the artifacts have been published in the "Staging" repository, by default they can be reviewed to determine whether they can be promoted in the "Release" repository or if they must be dropped instead.
2. Once the approval has been provided (i.e. in Nexus we "Close" the "Staging" repository to accomplish that), automatic checks are executed to ensure that artifacts met requirements of the Central Repository (https://central.sonatype.org/publish/requirements/).
3. Once the checks passed successfully, another manual action is required which consist of clicking on the "Release" button which will dispatch the promotion process.

It is useful to perform these manual actions for validating that our setup is correct. However, since we validated it successfully it's time to automate these actions!

The `nexus-staging-maven-plugin` is the recommended solution by the reference documentation about publishing artifacts to Maven Central (https://central.sonatype.org/publish/publish-maven). It automatically "Closes" the "Staging" repository. Furthermore, the `autoReleaseAfterClose` property from the plugin allows the automatic "Release" of the artifacts after the requirements checks passed successfully. That's the concrete plugin's plus-value!

---

#### Setup

The `nexus-staging-maven-plugin` does exactly the same things as the `maven-deploy-plugin`, but it perform additional actions automatically which are specific to Nexus repositories.

The setup instructions coming from the plugin's README file:
> In Maven3, the simplest needed to be done is to add the plugin to the build, and define it as extension and add wanted configuration. Plugin's LifecycleParticipant (a new Maven3 feature) will "automagically" do everything for you: it will disable maven-deploy-plugin:deploy executions, inject nexus-staging-maven-plugin:deploy executions instead.

=> https://github.com/sonatype/nexus-maven-plugins/tree/main/staging/maven-plugin#adding-the-plugin-to-your-build