### PR TITLE
ci(release): specify an HTTPS URL for the SCM URL definition in the `pom.xml` file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,7 +412,7 @@
     <scm>
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <url>git@github.com:Djaytan/bukkit-slf4j.git</url>
+        <url>https://github.com/Djaytan/bukkit-slf4j.git</url>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
Two reasons for this change:
* We tend to rely less and less on SSH for cloning Git repositories and now prefer HTTPS through access tokens (easier and secured solution)
* In the "External Resources" section of the library's Sonatype repository page (https://central.sonatype.com/artifact/com.djaytan.bukkit/bukkit-slf4j), the "Source Control" link is broken because of the current URL. The new one is supposed to fix that.

The newly specified SCM URL is supposed to be valid as per the Maven documentation: https://maven.apache.org/scm/git.html.