### PR TITLE
ci(github): allow SonarCloud scanner to generate security events for vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
 
     permissions:
       contents: read
+      security-events: write # Required by SonarCloud for reporting found security vulnerabilities
 
     steps:
       - name: Harden runner


### PR DESCRIPTION
The purpose is to resolve the following issue:
![image](https://github.com/Djaytan/bukkit-slf4j/assets/26904516/6f560f26-c609-4fd6-940a-536ead13857d)