### PR TITLE
ci(release): publish via the Central Portal

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
             objects.githubusercontent.com:443
             uploads.github.com:443
             repo.maven.apache.org:443
-            s01.oss.sonatype.org:443
+            central.sonatype.com:443
             jitpack.io:443
             repo.papermc.io:443
             api.nuget.org:443
@@ -68,9 +68,9 @@ jobs:
           java-version: 17
           distribution: temurin
           cache: maven
-          server-id: ossrh
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_TOKEN
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_TOKEN
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
@@ -79,8 +79,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           # Maven releasing-related properties
-          OSSRH_USERNAME: cEK6DM3d
-          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           # Hacky way of retrieving the released version tag name through a temporary file
           TMP_TAG_VERSION_NAME_FILE: ${{ runner.temp }}/tag_version_name

--- a/pom.xml
+++ b/pom.xml
@@ -274,14 +274,15 @@
                     <version>3.1.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.13</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.4.0</version>
                     <extensions>true</extensions>
                     <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        <publishingServerId>central</publishingServerId>
+                        <tokenAuth>true</tokenAuth>
+                        <autoPublish>true</autoPublish>
+                        <waitUntil>published</waitUntil>
                     </configuration>
                 </plugin>
 
@@ -460,17 +461,6 @@
     <ciManagement>
         <url>https://github.com/Djaytan/bukkit-slf4j/actions</url>
     </ciManagement>
-
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <profiles>
         <profile>


### PR DESCRIPTION
The setup has been migrated from OSSRH to Central Portal having having sent an email to the Central Team.

Here is the answer I got:

> Hello Loïc,
>
> We migrated your namespace as requested:
> * your user account lduboistermoz on s01.oss.sonatype.org can no longer be used to create deployments for the com.djaytan.bukkit namespace
> * your account on central.sonatype.com associated with user_id: github|26904516 has been updated to include the com.djaytan.bukkit namespace
>
> Please login to Central Portal and confirm you see com.djaytan.bukkit as verified under your list of namespaces. After this you could follow the publishing instructions in our documentation to publish your components.
>
> Please let us know if you have any questions.
>
> Thank you,
> The Central Team

cf. https://central.sonatype.org/publish-ea/publish-ea-guide/