### PR TITLE
fix: exclusively rely on the static logger name

### DIFF
--- a/src/main/java/com/djaytan/bukkit/slf4j/api/BukkitLoggerFactory.java
+++ b/src/main/java/com/djaytan/bukkit/slf4j/api/BukkitLoggerFactory.java
@@ -72,12 +72,10 @@ public final class BukkitLoggerFactory implements ILoggerFactory {
   @Override
   @Contract("null -> fail")
   public Logger getLogger(@Nullable String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("The logger name cannot be null");
-    }
+    // Name provided as argument is discarded in favor of the static Bukkit logger one
     if (staticLogger == null) {
       throw new IllegalStateException("The Bukkit logger must be defined first");
     }
-    return new BukkitLoggerAdapter(staticLogger, name);
+    return new BukkitLoggerAdapter(staticLogger, staticLogger.getName());
   }
 }

--- a/src/test/java/com/djaytan/bukkit/slf4j/api/BasicTests.java
+++ b/src/test/java/com/djaytan/bukkit/slf4j/api/BasicTests.java
@@ -212,7 +212,7 @@ final class BasicTests {
   }
 
   @Test
-  void bukkit_logger_name_must_always_be_disregarded() {
+  void bukkit_logger_name_must_always_be_used() {
     // Arrange
     String loggerName = "another logger name";
     var julLogger = Logger.getLogger(SAMPLE_LOGGER_NAME);
@@ -223,29 +223,7 @@ final class BasicTests {
     var slf4jLogger = LoggerFactory.getLogger(loggerName);
 
     // Assert
-    assertThat(slf4jLogger.getName()).isEqualTo(loggerName);
-  }
-
-  /**
-   * The <code>null</code> value for SLF4J logger name is not accepted.
-   *
-   * @see org.slf4j.ILoggerFactory#getLogger(String)
-   */
-  @Test
-  void consumer_get_an_exception_when_trying_to_get_a_logger_without_specifying_name() {
-    // Arrange
-    String undefinedLoggerName = null;
-    var julLogger = Logger.getLogger(SAMPLE_LOGGER_NAME);
-
-    BukkitLoggerFactory.provideBukkitLogger(julLogger);
-
-    // Act
-    ThrowingCallable call = () -> LoggerFactory.getLogger(undefinedLoggerName);
-
-    // Assert
-    assertThatThrownBy(call)
-        .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessage("The logger name cannot be null");
+    assertThat(slf4jLogger.getName()).isEqualTo(julLogger.getName());
   }
 
   @Test


### PR DESCRIPTION
Avoid the following kind of plugin output on PaperMC:

> [14:58:30] [Server thread/INFO]: [fr.djaytan.mc.jrppb.paper.listener.ListenerRegister] Event listeners registered.

And get the following output instead:

> [14:58:30] [Server thread/INFO]: [ThePluginLoggerNameHere] Event listeners registered.