### PR TITLE
ci(github): allow back Docker access to OpenSSF since required

### DIFF
--- a/.github/workflows/openssf.yml
+++ b/.github/workflows/openssf.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
-          disable-sudo-and-containers: true
+          disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             github.com:443


### PR DESCRIPTION
The error was:

> Error: An error occurred trying to start process '/usr/bin/docker' with working directory '/home/runner/work/docker-papermc-server/docker-papermc-server'. No such file or directory